### PR TITLE
test: add unit tests

### DIFF
--- a/api/index.spec.ts
+++ b/api/index.spec.ts
@@ -1,0 +1,65 @@
+jest.mock('path', () => ({ join: jest.fn() }));
+jest.mock('@vercel/analytics', () => ({ inject: jest.fn() }));
+
+const mockApp = () => ({
+  use: jest.fn(),
+  set: jest.fn(),
+  listen: jest.fn((_p: any, _h: any, cb: any) => cb && cb()),
+});
+
+const expressMock: any = jest.fn(() => mockApp());
+expressMock.static = jest.fn(() => 'static');
+
+jest.mock('express', () => expressMock);
+
+const connectMock = jest.fn(() => Promise.reject(new Error('fail')));
+jest.mock('../config/db', () => connectMock);
+
+const appRouter = 'appRouter';
+const authRouter = 'authRouter';
+const watchlistRouter = 'watchlistRouter';
+
+jest.mock('../routes/app', () => appRouter);
+jest.mock('../routes/auth', () => authRouter);
+jest.mock('../routes/watchlist', () => watchlistRouter);
+
+const baseConfig = {
+  APP_NAME: 'name',
+  APP_SUBTITLE: 'sub',
+  APP_DESCRIPTION: 'desc',
+  APP_URL: 'http://app',
+  API_HOST: 'host',
+  API_PORT: 1,
+};
+
+const loadModule = (useAuth: boolean) => {
+  jest.resetModules();
+  jest.doMock('../helpers/appHelper', () => ({ useAuth }));
+  jest.doMock('../config/app', () => baseConfig);
+  return require('./index');
+};
+
+describe('api/index', () => {
+  test('initialises with auth enabled', () => {
+    loadModule(true);
+    const app = expressMock.mock.results[0].value;
+    const localsMiddleware = app.use.mock.calls[0][0];
+    const res: any = { locals: {} };
+    localsMiddleware({}, res, () => {});
+    expect(res.locals.APP_NAME).toBe('name');
+    expect(connectMock).toHaveBeenCalled();
+    expect(app.use).toHaveBeenCalledWith('/', appRouter);
+    expect(app.use).toHaveBeenCalledWith('/user', authRouter);
+    expect(app.use).toHaveBeenCalledWith('/watchlist', watchlistRouter);
+    expect(app.listen).toHaveBeenCalled();
+  });
+
+  test('skips auth when disabled', () => {
+    expressMock.mockClear();
+    loadModule(false);
+    const app = expressMock.mock.results[0].value;
+    expect(connectMock).not.toHaveBeenCalled();
+    expect(app.use).toHaveBeenCalledWith('/', appRouter);
+    expect(app.use).not.toHaveBeenCalledWith('/user', authRouter);
+  });
+});

--- a/config/app.spec.ts
+++ b/config/app.spec.ts
@@ -1,0 +1,40 @@
+
+describe('config/app', () => {
+  afterEach(() => {
+    delete process.env.MONGO_USERNAME;
+    delete process.env.MONGO_PASSWORD;
+    delete process.env.MONGO_HOST;
+    delete process.env.MONGO_PORT;
+    delete process.env.MONGO_URI;
+    delete process.env.APP_URL;
+    delete process.env.VERCEL_URL;
+    jest.resetModules();
+  });
+
+  test('constructs mongo uri from credentials', () => {
+    process.env.MONGO_USERNAME = 'user';
+    process.env.MONGO_PASSWORD = 'pass';
+    process.env.MONGO_HOST = 'localhost';
+    process.env.MONGO_PORT = '27017';
+    jest.isolateModules(() => {
+      const config = require('./app').default;
+      expect(config.MONGO_DB_URI).toBe('mongodb://user:pass@localhost:27017');
+    });
+  });
+
+  test('uses provided mongo uri when credentials missing', () => {
+    process.env.MONGO_URI = 'mongodb://example';
+    jest.isolateModules(() => {
+      const config = require('./app').default;
+      expect(config.MONGO_DB_URI).toBe('mongodb://example');
+    });
+  });
+
+  test('app url prefers APP_URL then VERCEL_URL then localhost', () => {
+    process.env.VERCEL_URL = 'vercel.app';
+    jest.isolateModules(() => {
+      const config = require('./app').default;
+      expect(config.APP_URL).toBe('https://vercel.app');
+    });
+  });
+});

--- a/config/db.spec.ts
+++ b/config/db.spec.ts
@@ -1,0 +1,29 @@
+import mongoose from 'mongoose';
+
+jest.mock('mongoose', () => ({ connect: jest.fn() }));
+
+jest.mock('./app', () => ({
+  MONGO_DB_URI: 'mongodb://example',
+  MONGO_DB_NAME: 'db',
+}));
+
+import connectDB from './db';
+
+describe('config/db', () => {
+  test('connects to mongoose', async () => {
+    await connectDB();
+    expect(mongoose.connect).toHaveBeenCalledWith('mongodb://example', {
+      dbName: 'db',
+      family: 4,
+    });
+  });
+
+  test('handles connection error', async () => {
+    (mongoose.connect as jest.Mock).mockRejectedValueOnce({ message: 'fail' });
+    const exit = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error('exit ' + code);
+    }) as any);
+    await expect(connectDB()).rejects.toThrow('exit 1');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/controllers/appController.spec.ts
+++ b/controllers/appController.spec.ts
@@ -1,0 +1,86 @@
+import appController from './appController';
+import axios from 'axios';
+import { fetchOmdbData, fetchAndUpdatePosters } from '../helpers/appHelper';
+
+jest.mock('axios');
+jest.mock('../helpers/appHelper', () => ({
+  fetchOmdbData: jest.fn(),
+  fetchAndUpdatePosters: jest.fn(),
+}));
+
+jest.mock('../config/app', () => ({
+  VIDSRC_DOMAIN: 'domain',
+  APP_URL: 'http://app',
+  APP_NAME: 'name',
+  APP_SUBTITLE: '',
+  APP_DESCRIPTION: '',
+}));
+
+describe('controllers/appController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('getHome renders index with movies and series', async () => {
+    (axios.get as jest.Mock)
+      .mockResolvedValueOnce({ data: { result: [{ imdb_id: '1' }] } })
+      .mockResolvedValueOnce({ data: { result: [{ imdb_id: '2' }] } });
+    (fetchAndUpdatePosters as jest.Mock).mockResolvedValue(undefined);
+
+    const req: any = { query: {}, user: { id: 1 } };
+    const res: any = { locals: { APP_URL: 'http://app', CARD_TYPE: 'card' }, render: jest.fn() };
+
+    await appController.getHome(req, res, jest.fn());
+
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(fetchAndUpdatePosters).toHaveBeenCalledTimes(2);
+    expect(res.render).toHaveBeenCalledWith('index', expect.objectContaining({
+      newMovies: [{ imdb_id: '1' }],
+      newSeries: [{ imdb_id: '2' }],
+      card: 'card',
+      user: req.user,
+    }));
+  });
+
+  test('getView renders series view', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({});
+    const req: any = { params: { q: '', id: 'tt', type: 'series', season: '1', episode: '2' }, user: {} };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn() };
+
+    await appController.getView(req, res, jest.fn());
+    expect(fetchOmdbData).toHaveBeenCalledWith('tt', false);
+    expect(res.render).toHaveBeenCalledWith('view', expect.objectContaining({
+      season: '1',
+      episode: '2',
+      type: 'series',
+    }));
+  });
+
+  test('getView renders movie view', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({});
+    const req: any = { params: { q: '', id: 'tt', type: 'movie' }, user: {} };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn() };
+
+    await appController.getView(req, res, jest.fn());
+    expect(res.render).toHaveBeenCalledWith('view', expect.objectContaining({ type: 'movie' }));
+  });
+
+  test('getSearch redirects when query empty', async () => {
+    const req: any = { query: { q: '   ' }, user: {} };
+    const res: any = { locals: { APP_URL: 'http://app' }, redirect: jest.fn(), render: jest.fn() };
+    await appController.getSearch(req, res, jest.fn());
+    expect(res.redirect).toHaveBeenCalledWith('/');
+  });
+
+  test('getSearch renders search results', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({ Search: [{ Title: 'A' }] });
+    const req: any = { query: { q: 'test', type: 'movie' }, user: {} };
+    const res: any = { locals: { APP_URL: 'http://app', CARD_TYPE: 'card' }, redirect: jest.fn(), render: jest.fn() };
+    await appController.getSearch(req, res, jest.fn());
+    expect(fetchOmdbData).toHaveBeenCalledWith('test', true, 'movie');
+    expect(res.render).toHaveBeenCalledWith('search', expect.objectContaining({
+      results: [{ Title: 'A' }],
+      card: 'card',
+    }));
+  });
+});

--- a/helpers/appHelper.spec.ts
+++ b/helpers/appHelper.spec.ts
@@ -1,0 +1,83 @@
+import axios from 'axios';
+
+jest.mock('axios');
+
+jest.mock('../config/app', () => ({
+  OMDB_API_KEY: 'key',
+  OMDB_API_URL: 'http://omdb',
+  APP_URL: 'http://app',
+  MONGO_DB_URI: '',
+  MONGO_DB_NAME: '',
+  APP_NAME: '',
+  APP_SUBTITLE: '',
+  APP_DESCRIPTION: '',
+  API_HOST: 'localhost',
+  API_PORT: 3000,
+  VIDSRC_DOMAIN: 'domain',
+}));
+
+import appConfig from '../config/app';
+import * as helper from './appHelper';
+
+describe('helpers/appHelper', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetchOmdbData returns empty object when query missing', async () => {
+    const result = await helper.fetchOmdbData('', true);
+    expect(result).toEqual({});
+    expect(axios.request).not.toHaveBeenCalled();
+  });
+
+  test('fetchOmdbData calls axios with correct options', async () => {
+    (axios.request as jest.Mock).mockResolvedValue({ data: { Title: 'Test' } });
+    const data = await helper.fetchOmdbData('tt123', false, 'movie');
+    expect(axios.request).toHaveBeenCalledWith({
+      method: 'GET',
+      url: appConfig.OMDB_API_URL,
+      params: {
+        apikey: appConfig.OMDB_API_KEY,
+        type: 'movie',
+        i: 'tt123',
+      },
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(data).toEqual({ Title: 'Test' });
+  });
+
+  test('fetchAndUpdatePosters updates posters and defaults', async () => {
+    const shows: any[] = [{ imdb_id: '1' }, { imdb_id: '2' }];
+    const spy = jest
+      .spyOn(helper, 'fetchOmdbData')
+      .mockResolvedValueOnce({ Response: 'True', Poster: 'p1' })
+      .mockResolvedValueOnce({ Response: 'False' });
+    await helper.fetchAndUpdatePosters(shows);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(shows[0].poster).toBe('p1');
+    expect(shows[1].poster).toBe(`${appConfig.APP_URL}/images/no-binger.jpg`);
+  });
+
+  test('useAuth is false when no mongo uri', () => {
+    expect(helper.useAuth).toBe(false);
+  });
+
+  test('useAuth is true when mongo uri provided', () => {
+    jest.resetModules();
+    jest.doMock('../config/app', () => ({
+      OMDB_API_KEY: 'key',
+      OMDB_API_URL: 'http://omdb',
+      APP_URL: 'http://app',
+      MONGO_DB_URI: 'mongodb://db',
+      MONGO_DB_NAME: '',
+      APP_NAME: '',
+      APP_SUBTITLE: '',
+      APP_DESCRIPTION: '',
+      API_HOST: 'localhost',
+      API_PORT: 3000,
+      VIDSRC_DOMAIN: 'domain',
+    }));
+    const mod = require('./appHelper');
+    expect(mod.useAuth).toBe(true);
+  });
+});

--- a/middleware/auth.spec.ts
+++ b/middleware/auth.spec.ts
@@ -1,0 +1,19 @@
+import { ensureAuthenticated } from './auth';
+
+describe('middleware/auth', () => {
+  test('calls next when authenticated', () => {
+    const req: any = { isAuthenticated: () => true };
+    const res: any = { redirect: jest.fn() };
+    const next = jest.fn();
+    ensureAuthenticated(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.redirect).not.toHaveBeenCalled();
+  });
+
+  test('redirects when not authenticated', () => {
+    const req: any = { isAuthenticated: () => false };
+    const res: any = { redirect: jest.fn() };
+    ensureAuthenticated(req, res, jest.fn());
+    expect(res.redirect).toHaveBeenCalledWith('/user/login');
+  });
+});

--- a/middleware/dbSession.spec.ts
+++ b/middleware/dbSession.spec.ts
@@ -1,0 +1,49 @@
+jest.mock('../config/passport', () => jest.fn());
+jest.mock('body-parser', () => ({ urlencoded: jest.fn(() => 'bp') }));
+jest.mock('express-session', () => jest.fn(() => 'sessionMw'));
+jest.mock('connect-flash', () => jest.fn(() => 'flashMw'));
+jest.mock('passport', () => ({
+  initialize: jest.fn(() => 'initMw'),
+  session: jest.fn(() => 'sessMw'),
+}));
+jest.mock('connect-mongo', () => ({ __esModule: true, default: { create: jest.fn(() => 'mongoStore') } }));
+
+const createAppMock = (uri: string) => {
+  jest.resetModules();
+  jest.doMock('../config/app', () => ({
+    MONGO_DB_URI: uri,
+    APP_SECRET: 'secret',
+    MONGO_DB_NAME: 'db',
+  }));
+  return require('./dbSession').default;
+};
+
+describe('middleware/dbSession', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test('returns early when no mongo uri', () => {
+    const dbSession = createAppMock('');
+    const router: any = { use: jest.fn() };
+    dbSession(router);
+    expect(router.use).not.toHaveBeenCalled();
+  });
+
+  test('configures middleware when mongo uri provided', () => {
+    const dbSession = createAppMock('mongodb://localhost');
+    const passportConfig = require('../config/passport');
+    const router: any = { use: jest.fn() };
+    dbSession(router);
+    expect(passportConfig).toHaveBeenCalled();
+    expect(router.use).toHaveBeenCalled();
+    // Execute flash middleware to cover internal callback
+    const flashMiddleware = router.use.mock.calls[3][0];
+    const req: any = {
+      flash: jest.fn().mockReturnValueOnce('ok').mockReturnValueOnce('err').mockReturnValueOnce('err'),
+    };
+    const res: any = { locals: {} };
+    const next = jest.fn();
+    flashMiddleware(req, res, next);
+    expect(res.locals.success_msg).toBe('ok');
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/models/Watchlist.spec.ts
+++ b/models/Watchlist.spec.ts
@@ -1,0 +1,43 @@
+import Watchlist from './Watchlist';
+
+describe('models/Watchlist', () => {
+  const methods = (Watchlist as any).schema.methods;
+
+  test('isInWatchlist determines presence', async () => {
+    const doc: any = { items: [{ imdbId: 'a' }] };
+    expect(await methods.isInWatchlist.call(doc, 'a')).toBe(true);
+    expect(await methods.isInWatchlist.call(doc, 'b')).toBe(false);
+  });
+
+  test('addToWatchlist adds when missing', async () => {
+    const doc: any = { items: [], save: jest.fn() };
+    doc.isInWatchlist = methods.isInWatchlist.bind(doc);
+    await methods.addToWatchlist.call(doc, 'id', 'Title', 'Poster', 'movie');
+    expect(doc.items).toHaveLength(1);
+    expect(doc.save).toHaveBeenCalled();
+  });
+
+  test('addToWatchlist skips existing', async () => {
+    const doc: any = { items: [{ imdbId: 'id' }], save: jest.fn() };
+    doc.isInWatchlist = methods.isInWatchlist.bind(doc);
+    await methods.addToWatchlist.call(doc, 'id', 'Title', 'Poster', 'movie');
+    expect(doc.items).toHaveLength(1);
+    expect(doc.save).not.toHaveBeenCalled();
+  });
+
+  test('deleteFromWatchlist removes when present', async () => {
+    const doc: any = { items: [{ imdbId: 'id' }, { imdbId: 'id2' }], save: jest.fn() };
+    doc.isInWatchlist = methods.isInWatchlist.bind(doc);
+    await methods.deleteFromWatchlist.call(doc, 'id');
+    expect(doc.items).toEqual([{ imdbId: 'id2' }]);
+    expect(doc.save).toHaveBeenCalled();
+  });
+
+  test('deleteFromWatchlist does nothing when absent', async () => {
+    const doc: any = { items: [{ imdbId: 'id2' }], save: jest.fn() };
+    doc.isInWatchlist = methods.isInWatchlist.bind(doc);
+    await methods.deleteFromWatchlist.call(doc, 'id');
+    expect(doc.items).toEqual([{ imdbId: 'id2' }]);
+    expect(doc.save).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for API bootstrap, config, helpers, middleware and controllers
- validate MongoDB connection and error paths
- cover watchlist model operations

## Testing
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689a7c7973408332897326644a63f090