### PR TITLE
Add core unit test coverage

### DIFF
--- a/config/app.spec.ts
+++ b/config/app.spec.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('appConfig', () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.resetModules();
+  });
+
+  it('builds mongo uri from credentials and uses APP_URL when provided', () => {
+    process.env.MONGO_USERNAME = 'user';
+    process.env.MONGO_PASSWORD = 'pass';
+    process.env.MONGO_HOST = 'localhost';
+    process.env.MONGO_PORT = '27017';
+    process.env.APP_URL = 'https://example.com';
+
+    const config = require('./app').default;
+    expect(config.MONGO_DB_URI).toBe('mongodb://user:pass@localhost:27017');
+    expect(config.APP_URL).toBe('https://example.com');
+  });
+
+  it('uses MONGO_URI and default APP_URL when credentials missing', () => {
+    delete process.env.MONGO_USERNAME;
+    delete process.env.MONGO_PASSWORD;
+    process.env.MONGO_URI = 'mongodb://other';
+    delete process.env.APP_URL;
+    delete process.env.VERCEL_URL;
+
+    const config = require('./app').default;
+    expect(config.MONGO_DB_URI).toBe('mongodb://other');
+    expect(config.APP_URL).toBe('http://localhost:3000');
+  });
+
+  it('constructs APP_URL from VERCEL_URL when APP_URL not provided', () => {
+    process.env.MONGO_URI = 'mongodb://other';
+    delete process.env.APP_URL;
+    process.env.VERCEL_URL = 'myapp.vercel.app';
+
+    const config = require('./app').default;
+    expect(config.APP_URL).toBe('https://myapp.vercel.app');
+  });
+});

--- a/config/db.spec.ts
+++ b/config/db.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+
+jest.mock('mongoose', () => ({ connect: jest.fn() }));
+
+const mongoose = require('mongoose');
+const connectDB = require('./db').default;
+
+describe('connectDB', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs success when connection succeeds', async () => {
+    (mongoose.connect as any).mockResolvedValue(undefined);
+    const log = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    await connectDB();
+    expect(mongoose.connect).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith('MongoDB Connected');
+    log.mockRestore();
+  });
+
+  it('logs error and exits on failure', async () => {
+    (mongoose.connect as any).mockRejectedValue(new Error('fail'));
+    const err = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const exit = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as any);
+    await connectDB();
+    expect(err).toHaveBeenCalledWith('fail');
+    expect(exit).toHaveBeenCalledWith(1);
+    err.mockRestore();
+    exit.mockRestore();
+  });
+});

--- a/helpers/appHelper.spec.ts
+++ b/helpers/appHelper.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import appConfig from '../config/app';
+import axios from 'axios';
+
+jest.mock('axios');
+
+describe('fetchOmdbData', () => {
+  it('returns empty object when query missing', async () => {
+    const helper = await import('./appHelper');
+    const data = await helper.fetchOmdbData('');
+    expect(data).toEqual({});
+  });
+
+  it('requests data when query provided', async () => {
+    (axios.request as any).mockResolvedValue({ data: { Response: 'True' } });
+    const helper = await import('./appHelper');
+    const data = await helper.fetchOmdbData('tt123', false, 'movie');
+    expect((axios.request as any)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ apikey: appConfig.OMDB_API_KEY, i: 'tt123', type: 'movie' }),
+      })
+    );
+    expect(data).toEqual({ Response: 'True' });
+  });
+});
+
+describe('fetchAndUpdatePosters', () => {
+  it('updates poster urls based on omdb response', async () => {
+    const module = await import('./appHelper');
+    const spy = jest.spyOn(module, 'fetchOmdbData');
+    spy
+      .mockResolvedValueOnce({ Response: 'True', Poster: 'poster.jpg' })
+      .mockResolvedValueOnce({ Response: 'True', Poster: 'N/A' })
+      .mockResolvedValueOnce({ Response: 'False' });
+
+    const shows: any[] = [{ imdb_id: '1' }, { imdb_id: '2' }, { imdb_id: '3' }];
+    await module.fetchAndUpdatePosters(shows);
+    expect(shows[0].poster).toBe('poster.jpg');
+    expect(shows[1].poster).toBe(`${appConfig.APP_URL}/images/no-binger.jpg`);
+    expect(shows[2].poster).toBe(`${appConfig.APP_URL}/images/no-binger.jpg`);
+    spy.mockRestore();
+  });
+});
+
+describe('useAuth', () => {
+  it('reflects presence of MONGO_DB_URI', async () => {
+    jest.resetModules();
+    jest.doMock('../config/app', () => ({ MONGO_DB_URI: 'mongo' }));
+    const { useAuth } = await import('./appHelper');
+    expect(useAuth).toBe(true);
+
+    jest.resetModules();
+    jest.doMock('../config/app', () => ({ MONGO_DB_URI: '' }));
+    const { useAuth: noAuth } = await import('./appHelper');
+    expect(noAuth).toBe(false);
+  });
+});

--- a/middleware/auth.spec.ts
+++ b/middleware/auth.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { ensureAuthenticated } from './auth';
+
+describe('ensureAuthenticated', () => {
+  it('calls next when authenticated', () => {
+    const req = { isAuthenticated: () => true } as any;
+    const res = { redirect: jest.fn() } as any;
+    const next = jest.fn();
+    ensureAuthenticated(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.redirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects when not authenticated', () => {
+    const req = { isAuthenticated: () => false } as any;
+    const res = { redirect: jest.fn() } as any;
+    const next = jest.fn();
+    ensureAuthenticated(req, res, next);
+    expect(res.redirect).toHaveBeenCalledWith('/user/login');
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/middleware/dbSession.spec.ts
+++ b/middleware/dbSession.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+
+jest.mock('../config/passport', () => jest.fn());
+
+const bodyParserUse = jest.fn(() => 'bodyParser');
+jest.mock('body-parser', () => ({ urlencoded: () => bodyParserUse() }));
+
+const sessionUse = jest.fn(() => 'session');
+jest.mock('express-session', () => () => sessionUse());
+
+const flashUse = jest.fn(() => 'flash');
+jest.mock('connect-flash', () => () => flashUse());
+
+const mongoCreate = jest.fn((opts?: any) => 'store');
+jest.mock('connect-mongo', () => ({ __esModule: true, default: { create: (opts: any) => mongoCreate(opts) } }));
+
+const passportInit = jest.fn(() => 'init');
+const passportSess = jest.fn(() => 'sess');
+jest.mock('passport', () => ({ initialize: () => passportInit(), session: () => passportSess() }));
+
+describe('dbSessionMiddleware', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('returns early when no mongo uri', () => {
+    jest.doMock('../config/app', () => ({ MONGO_DB_URI: '', APP_SECRET: 'sec', MONGO_DB_NAME: 'db' }));
+    const router = { use: jest.fn() } as any;
+    const middleware = require('./dbSession').default;
+    middleware(router);
+    expect(router.use).not.toHaveBeenCalled();
+  });
+
+  it('sets up session when mongo uri provided', () => {
+    jest.doMock('../config/app', () => ({ MONGO_DB_URI: 'mongo', APP_SECRET: 'sec', MONGO_DB_NAME: 'db' }));
+    const router = { use: jest.fn() } as any;
+    const middleware = require('./dbSession').default;
+    middleware(router);
+    expect(router.use).toHaveBeenCalled();
+    expect(bodyParserUse).toHaveBeenCalled();
+    expect(sessionUse).toHaveBeenCalled();
+    expect(flashUse).toHaveBeenCalled();
+    expect(passportInit).toHaveBeenCalled();
+    expect(passportSess).toHaveBeenCalled();
+    expect(mongoCreate).toHaveBeenCalledWith({ mongoUrl: 'mongo', dbName: 'db' });
+  });
+});

--- a/models/User.spec.ts
+++ b/models/User.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import bcrypt from 'bcryptjs';
+import User from './User';
+
+describe('User model', () => {
+  it('compares password correctly', async () => {
+    const compare = jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as any);
+    const user: any = new User({ username: 'u', password: 'hashed' });
+    const result = await user.matchPassword('plain');
+    expect(compare).toHaveBeenCalledWith('plain', 'hashed');
+    expect(result).toBe(true);
+  });
+});

--- a/models/Watchlist.spec.ts
+++ b/models/Watchlist.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import Watchlist, { IWatchlistItem } from './Watchlist';
+import mongoose from 'mongoose';
+
+describe('Watchlist model methods', () => {
+  it('isInWatchlist checks presence', async () => {
+    const w = new Watchlist({ userId: new mongoose.Types.ObjectId(), items: [{ imdbId: '1', title: 't', poster: 'p', type: 'movie' }] });
+    expect(await w.isInWatchlist('1')).toBe(true);
+    expect(await w.isInWatchlist('2')).toBe(false);
+  });
+
+  it('addToWatchlist adds when missing', async () => {
+    const w: any = new Watchlist({ userId: new mongoose.Types.ObjectId(), items: [] });
+    w.save = jest.fn();
+    await w.addToWatchlist('1', 't', 'p', 'movie');
+    expect(w.items).toHaveLength(1);
+    expect(w.save).toHaveBeenCalled();
+
+    w.save.mockClear();
+    await w.addToWatchlist('1', 't', 'p', 'movie');
+    expect(w.items).toHaveLength(1);
+    expect(w.save).not.toHaveBeenCalled();
+  });
+
+  it('deleteFromWatchlist removes existing items', async () => {
+    const w: any = new Watchlist({ userId: new mongoose.Types.ObjectId(), items: [{ imdbId: '1', title: 't', poster: 'p', type: 'movie' }] });
+    w.save = jest.fn();
+    await w.deleteFromWatchlist('1');
+    expect(w.items).toHaveLength(0);
+    expect(w.save).toHaveBeenCalled();
+
+    w.save.mockClear();
+    await w.deleteFromWatchlist('2');
+    expect(w.items).toHaveLength(0);
+    expect(w.save).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for environment-driven app configuration and database connector
- cover helper utilities, auth middleware, and DB session middleware
- add model tests for User and Watchlist collections

## Testing
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689a7c7973408332897326644a63f090