### PR TITLE
feat: add viewing history tracking

### DIFF
--- a/controllers/appController.spec.ts
+++ b/controllers/appController.spec.ts
@@ -1,11 +1,17 @@
 import appController from './appController';
 import axios from 'axios';
 import { fetchOmdbData, fetchAndUpdatePosters } from '../helpers/appHelper';
+import History from '../models/History';
 
 jest.mock('axios');
 jest.mock('../helpers/appHelper', () => ({
   fetchOmdbData: jest.fn(),
   fetchAndUpdatePosters: jest.fn(),
+}));
+
+jest.mock('../models/History', () => ({
+  findOne: jest.fn(),
+  findOneAndUpdate: jest.fn(),
 }));
 
 jest.mock('../config/app', () => ({
@@ -64,11 +70,15 @@ describe('controllers/appController', () => {
 
   test('getView renders series view', async () => {
     (fetchOmdbData as jest.Mock).mockResolvedValue({});
-    const req: any = { params: { q: '', id: 'tt', type: 'series', season: '1', episode: '2' }, user: {} };
-    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn() };
+    const req: any = { params: { q: '', id: 'tt', type: 'series', season: '1', episode: '2' }, user: { id: 'u1' } };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn(), redirect: jest.fn() };
 
     await appController.getView(req, res, jest.fn());
-    expect(fetchOmdbData).toHaveBeenCalledWith('tt', false);
+    expect(History.findOneAndUpdate).toHaveBeenCalledWith(
+      { userId: 'u1', imdbId: 'tt' },
+      { $set: { type: 'series', lastSeason: 1, lastEpisode: 2 } },
+      { upsert: true }
+    );
     expect(res.render).toHaveBeenCalledWith('view', expect.objectContaining({
       season: '1',
       episode: '2',
@@ -78,11 +88,18 @@ describe('controllers/appController', () => {
 
   test('getView defaults season and episode when missing', async () => {
     (fetchOmdbData as jest.Mock).mockResolvedValue({});
-    const req: any = { params: { q: '', id: 'tt', type: 'series' }, user: {} };
-    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn() };
+    (History.findOne as jest.Mock).mockResolvedValue(undefined);
+    const req: any = { params: { q: '', id: 'tt', type: 'series' }, user: { id: 'u1' } };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn(), redirect: jest.fn() };
 
     await appController.getView(req, res, jest.fn());
 
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(History.findOneAndUpdate).toHaveBeenCalledWith(
+      { userId: 'u1', imdbId: 'tt' },
+      { $set: { type: 'series', lastSeason: 1, lastEpisode: 1 } },
+      { upsert: true }
+    );
     expect(res.render).toHaveBeenCalledWith('view', expect.objectContaining({
       season: '1',
       episode: '1',
@@ -91,11 +108,110 @@ describe('controllers/appController', () => {
 
   test('getView renders movie view', async () => {
     (fetchOmdbData as jest.Mock).mockResolvedValue({});
-    const req: any = { params: { q: '', id: 'tt', type: 'movie' }, user: {} };
+    (History.findOneAndUpdate as jest.Mock).mockResolvedValue({ watched: true });
+    const req: any = { params: { q: '', id: 'tt', type: 'movie' }, user: { id: 'u1' } };
     const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn() };
 
     await appController.getView(req, res, jest.fn());
-    expect(res.render).toHaveBeenCalledWith('view', expect.objectContaining({ type: 'movie' }));
+    expect(History.findOneAndUpdate).toHaveBeenCalledWith(
+      { userId: 'u1', imdbId: 'tt' },
+      { $set: { type: 'movie', watched: true } },
+      { upsert: true, new: true }
+    );
+    expect(res.render).toHaveBeenCalledWith('view', expect.objectContaining({ type: 'movie', watched: true }));
+  });
+
+  test('getView handles missing history on movie view', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({});
+    (History.findOneAndUpdate as jest.Mock).mockResolvedValue(null);
+    const req: any = { params: { q: '', id: 'tt', type: 'movie' }, user: { id: 'u1' } };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn() };
+
+    await appController.getView(req, res, jest.fn());
+
+    expect(res.render).toHaveBeenCalledWith(
+      'view',
+      expect.objectContaining({ type: 'movie', watched: false })
+    );
+  });
+
+  test('getView redirects to history position for series', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({});
+    (History.findOne as jest.Mock).mockResolvedValue({ lastSeason: 5, lastEpisode: 11 });
+    const req: any = { params: { q: '', id: 'tt', type: 'series' }, user: { id: 'u1' } };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn(), redirect: jest.fn() };
+
+    await appController.getView(req, res, jest.fn());
+    expect(res.redirect).toHaveBeenCalledWith('/view/tt/series/5/11');
+    expect(History.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('getView ignores malformed history and uses defaults', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({});
+    (History.findOne as jest.Mock).mockResolvedValue({ lastSeason: 'abc', lastEpisode: null });
+    const req: any = { params: { q: '', id: 'tt', type: 'series' }, user: { id: 'u1' } };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn(), redirect: jest.fn() };
+
+    await appController.getView(req, res, jest.fn());
+
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(History.findOneAndUpdate).toHaveBeenCalledWith(
+      { userId: 'u1', imdbId: 'tt' },
+      { $set: { type: 'series', lastSeason: 1, lastEpisode: 1 } },
+      { upsert: true }
+    );
+    expect(res.render).toHaveBeenCalledWith(
+      'view',
+      expect.objectContaining({ season: '1', episode: '1' })
+    );
+  });
+
+  test('getView series without user does not query history', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({});
+    const req: any = { params: { q: '', id: 'tt', type: 'series' } };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn(), redirect: jest.fn() };
+
+    await appController.getView(req, res, jest.fn());
+
+    expect(History.findOne).not.toHaveBeenCalled();
+    expect(History.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(res.render).toHaveBeenCalledWith(
+      'view',
+      expect.objectContaining({ season: '1', episode: '1' })
+    );
+  });
+
+  test('getView propagates errors from History.findOne', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({});
+    (History.findOne as jest.Mock).mockRejectedValue(new Error('fail'));
+    const req: any = { params: { q: '', id: 'tt', type: 'series' }, user: { id: 'u1' } };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn(), redirect: jest.fn() };
+    const next = jest.fn();
+
+    await appController.getView(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  test('getView propagates errors from History.findOneAndUpdate', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({});
+    (History.findOneAndUpdate as jest.Mock).mockRejectedValue(new Error('fail'));
+    const req: any = { params: { q: '', id: 'tt', type: 'movie' }, user: { id: 'u1' } };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn() };
+    const next = jest.fn();
+
+    await appController.getView(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  test('getView movie without user skips history', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({});
+    const req: any = { params: { q: '', id: 'tt', type: 'movie' } };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn() };
+
+    await appController.getView(req, res, jest.fn());
+    expect(History.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
   test('getSearch redirects when query empty', async () => {

--- a/controllers/appController.ts
+++ b/controllers/appController.ts
@@ -9,6 +9,7 @@ import {Request, Response} from 'express';
 
 import appConfig from '../config/app';
 import {fetchOmdbData, fetchAndUpdatePosters} from '../helpers/appHelper';
+import History from '../models/History';
 
 /**
  * Extended Express Request interface with optional user property.
@@ -105,12 +106,41 @@ const appController = {
   getView: asyncHandler(async (req: AuthRequest, res: Response) => {
     const query = req.params.q || '';
     const id = req.params.id;
-    let type = req.params.type;
-    let t = 'movie';
+    const type = req.params.type;
 
     if (type === 'series') {
-      const season = req.params.season || '1';
-      const episode = req.params.episode || '1';
+      let season = req.params.season;
+      let episode = req.params.episode;
+
+      if ((!season || !episode) && req.user) {
+        const history = await History.findOne({
+          userId: req.user.id,
+          imdbId: id,
+        });
+        if (history) {
+          const { lastSeason, lastEpisode } = history as any;
+          if (
+            Number.isInteger(lastSeason) &&
+            Number.isInteger(lastEpisode) &&
+            lastSeason > 0 &&
+            lastEpisode > 0
+          ) {
+            return res.redirect(`/view/${id}/series/${lastSeason}/${lastEpisode}`);
+          }
+        }
+      }
+
+      season = season || '1';
+      episode = episode || '1';
+
+      if (req.user) {
+        await History.findOneAndUpdate(
+          { userId: req.user.id, imdbId: id },
+          { $set: { type: 'series', lastSeason: Number(season), lastEpisode: Number(episode) } },
+          { upsert: true }
+        );
+      }
+
       const iframeSrc = `https://${appConfig.VIDSRC_DOMAIN}/embed/tv?imdb=${id}&season=${season}&episode=${episode}`;
       const canonical = `${res.locals.APP_URL}/view/${id}/${type}/${season}/${episode}`;
       const data = await fetchOmdbData(id, false);
@@ -127,7 +157,17 @@ const appController = {
       });
     }
 
-    const iframeSrc = `https://${appConfig.VIDSRC_DOMAIN}/embed/${t}/${id}`;
+    let watched = false;
+    if (req.user) {
+      const history = await History.findOneAndUpdate(
+        { userId: req.user.id, imdbId: id },
+        { $set: { type: 'movie', watched: true } },
+        { upsert: true, new: true }
+      );
+      watched = history?.watched || false;
+    }
+
+    const iframeSrc = `https://${appConfig.VIDSRC_DOMAIN}/embed/movie/${id}`;
     const canonical = `${res.locals.APP_URL}/view/${id}/${type}`;
     const data = await fetchOmdbData(id, false);
     res.render('view', {
@@ -138,6 +178,7 @@ const appController = {
       type,
       canonical,
       user: req.user,
+      watched,
     });
   }),
 

--- a/migrations/20240715120000-create-history-collection.js
+++ b/migrations/20240715120000-create-history-collection.js
@@ -1,0 +1,43 @@
+/**
+ * History collection migration.
+ * @module migrations/createHistory
+ * @description Creates the 'histories' collection with a compound index.
+ */
+module.exports = {
+  /**
+   * Creates the 'histories' collection and adds an index on userId and imdbId.
+   * @param {import('mongodb').Db} db - The MongoDB database instance.
+   * @param {import('mongodb').MongoClient} client - The MongoDB client instance.
+   * @returns {Promise<void>}
+   */
+  async up(db, client) {
+    const session = client.startSession();
+    try {
+      await session.withTransaction(async () => {
+        await db.createCollection('histories');
+        await db
+          .collection('histories')
+          .createIndex({ userId: 1, imdbId: 1 }, { unique: true });
+      });
+    } finally {
+      await session.endSession();
+    }
+  },
+
+  /**
+   * Drops the 'histories' collection.
+   * @param {import('mongodb').Db} db - The MongoDB database instance.
+   * @param {import('mongodb').MongoClient} client - The MongoDB client instance.
+   * @returns {Promise<void>}
+   */
+  async down(db, client) {
+    const session = client.startSession();
+    try {
+      await session.withTransaction(async () => {
+        await db.collection('histories').drop();
+      });
+    } finally {
+      await session.endSession();
+    }
+  },
+};

--- a/models/History.spec.ts
+++ b/models/History.spec.ts
@@ -1,0 +1,20 @@
+import History from './History';
+
+describe('models/History', () => {
+  const methods = (History as any).schema.methods;
+
+  test('markWatched sets watched and saves', async () => {
+    const doc: any = { watched: false, save: jest.fn() };
+    await methods.markWatched.call(doc);
+    expect(doc.watched).toBe(true);
+    expect(doc.save).toHaveBeenCalled();
+  });
+
+  test('updatePosition updates season and episode and saves', async () => {
+    const doc: any = { lastSeason: 1, lastEpisode: 1, save: jest.fn() };
+    await methods.updatePosition.call(doc, 2, 3);
+    expect(doc.lastSeason).toBe(2);
+    expect(doc.lastEpisode).toBe(3);
+    expect(doc.save).toHaveBeenCalled();
+  });
+});

--- a/models/History.ts
+++ b/models/History.ts
@@ -1,0 +1,48 @@
+/**
+ * @module models/History
+ * @description Mongoose model for tracking user watch history.
+ */
+
+import mongoose, { Schema, Document, Types } from 'mongoose';
+
+export interface IHistory extends Document {
+  userId: Types.ObjectId;
+  imdbId: string;
+  type: 'movie' | 'series';
+  watched: boolean;
+  lastSeason?: number;
+  lastEpisode?: number;
+  markWatched(): Promise<void>;
+  updatePosition(season: number, episode: number): Promise<void>;
+}
+
+const definition = {
+  userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  imdbId: { type: String, required: true },
+  type: { type: String, enum: ['movie', 'series'], required: true },
+  watched: { type: Boolean, default: false },
+  lastSeason: { type: Number, required: false },
+  lastEpisode: { type: Number, required: false },
+};
+
+const HistorySchema = new Schema<IHistory>(definition, { timestamps: true });
+
+HistorySchema.index({ userId: 1, imdbId: 1 }, { unique: true });
+
+HistorySchema.methods.markWatched = async function (this: IHistory): Promise<void> {
+  this.watched = true;
+  await this.save();
+};
+
+HistorySchema.methods.updatePosition = async function (
+  this: IHistory,
+  season: number,
+  episode: number
+): Promise<void> {
+  this.lastSeason = season;
+  this.lastEpisode = episode;
+  await this.save();
+};
+
+const History = mongoose.model<IHistory>('History', HistorySchema);
+export default History;


### PR DESCRIPTION
## Summary
- add History model and migration to record viewing progress
- track watch state and last episode in appController
- expose watch status to templates and cover new cases in tests
- harden history lookups and exercise error cases

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx ejslint ./views/*.ejs ./views/**/*.ejs`
- `npx jest --coverage`


------
https://chatgpt.com/codex/tasks/task_e_689bd0db2aac8332bcc34c8f13661e7c