### PR TITLE
feat: improve series navigation and episode listings

### DIFF
--- a/controllers/appController.spec.ts
+++ b/controllers/appController.spec.ts
@@ -1,12 +1,13 @@
 import appController from './appController';
 import axios from 'axios';
-import { fetchOmdbData, fetchAndUpdatePosters } from '../helpers/appHelper';
+import { fetchOmdbData, fetchAndUpdatePosters, getSeriesDetail } from '../helpers/appHelper';
 import History from '../models/History';
 
 jest.mock('axios');
 jest.mock('../helpers/appHelper', () => ({
   fetchOmdbData: jest.fn(),
   fetchAndUpdatePosters: jest.fn(),
+  getSeriesDetail: jest.fn(),
 }));
 
 jest.mock('../models/History', () => ({
@@ -25,6 +26,11 @@ jest.mock('../config/app', () => ({
 describe('controllers/appController', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (getSeriesDetail as jest.Mock).mockResolvedValue({
+      totalSeasons: 1,
+      totalEpisodes: 1,
+      seasons: [{ season: 1, episodes: [{ episode: 1, title: 'E1' }] }],
+    });
   });
 
   test('getHome renders index with movies and series', async () => {
@@ -79,6 +85,7 @@ describe('controllers/appController', () => {
       { $set: { type: 'series', lastSeason: 1, lastEpisode: 2 } },
       { upsert: true }
     );
+    expect(getSeriesDetail).toHaveBeenCalledWith('tt');
     expect(res.render).toHaveBeenCalledWith('view', expect.objectContaining({
       season: '1',
       episode: '2',

--- a/controllers/appController.ts
+++ b/controllers/appController.ts
@@ -5,20 +5,12 @@
 
 import axios from 'axios';
 import asyncHandler from 'express-async-handler';
-import {Request, Response} from 'express';
+import { Response } from 'express';
 
 import appConfig from '../config/app';
-import {fetchOmdbData, fetchAndUpdatePosters} from '../helpers/appHelper';
+import {fetchOmdbData, fetchAndUpdatePosters, getSeriesDetail} from '../helpers/appHelper';
 import History from '../models/History';
-
-/**
- * Extended Express Request interface with optional user property.
- * @interface AuthRequest
- * @extends {Request}
- */
-interface AuthRequest extends Request {
-  user?: any;
-}
+import type { AuthRequest } from '../types/interfaces';
 
 /**
  * @namespace appController
@@ -144,6 +136,7 @@ const appController = {
       const iframeSrc = `https://${appConfig.VIDSRC_DOMAIN}/embed/tv?imdb=${id}&season=${season}&episode=${episode}`;
       const canonical = `${res.locals.APP_URL}/view/${id}/${type}/${season}/${episode}`;
       const data = await fetchOmdbData(id, false);
+      const seriesDetail = await getSeriesDetail(id);
       return res.render('view', {
         data,
         iframeSrc,
@@ -152,6 +145,7 @@ const appController = {
         type,
         season,
         episode,
+        seriesDetail,
         canonical,
         user: req.user,
       });

--- a/types/interfaces.d.ts
+++ b/types/interfaces.d.ts
@@ -1,0 +1,21 @@
+import { Request } from 'express';
+
+export interface EpisodeInfo {
+  episode: number;
+  title?: string;
+}
+
+export interface SeasonDetail {
+  season: number;
+  episodes: EpisodeInfo[];
+}
+
+export interface SeriesDetail {
+  totalSeasons: number;
+  totalEpisodes: number;
+  seasons: SeasonDetail[];
+}
+
+export interface AuthRequest extends Request {
+  user?: any;
+}

--- a/views/partials/series-buttons.ejs
+++ b/views/partials/series-buttons.ejs
@@ -1,0 +1,43 @@
+<%
+const seasonNum = Number(season);
+const episodeNum = Number(episode);
+const totalSeasons = seriesDetail?.totalSeasons || 0;
+const currentSeason = seriesDetail?.seasons?.find(s => s.season === seasonNum) || { episodes: [] };
+const maxEpisodes = currentSeason.episodes.length;
+let prevDisabled = false;
+let nextDisabled = false;
+let prevLink = `${APP_URL}/view/${id}/${type}/${seasonNum}/${episodeNum - 1}`;
+let nextLink = `${APP_URL}/view/${id}/${type}/${seasonNum}/${episodeNum + 1}`;
+if (episodeNum <= 1) {
+  if (seasonNum > 1) {
+    const prevSeason = seasonNum - 1;
+    const prevSeasonEpisodes = seriesDetail.seasons.find(s => s.season === prevSeason)?.episodes.length || 0;
+    prevLink = `${APP_URL}/view/${id}/${type}/${prevSeason}/${prevSeasonEpisodes}`;
+  } else {
+    prevDisabled = true;
+    prevLink = '#';
+  }
+}
+if (episodeNum >= maxEpisodes) {
+  if (seasonNum < totalSeasons) {
+    const nextSeason = seasonNum + 1;
+    nextLink = `${APP_URL}/view/${id}/${type}/${nextSeason}/1`;
+  } else {
+    nextDisabled = true;
+    nextLink = '#';
+  }
+}
+%>
+<div id="series-buttons" class="d-absolute p-0 ps-2 m-0 m-sm-n1 end-0">
+    <button type="button" class="btn btn-dark btn-md mb-1" disabled>
+        Season <span class="badge bg-warning text-dark"><%= season %></span>
+    </button>
+    <button type="button" class="btn btn-dark btn-md mb-1" disabled>
+        Episode <span class="badge bg-info text-dark"><%= episode %></span>
+    </button>
+    <div class="mb-2 w-auto">
+        <a href="<%= prevLink %>" class="btn text-primary bg-primary-subtle border border-primary-subtle btn-sm p-2 <%= prevDisabled ? 'disabled' : '' %>"><i class="bi bi-caret-left-square"></i> Previous</a>
+        <a href="<%= APP_URL %>/watchlist" class="btn text-secondary bg-secondary-subtle border border-secondary-subtle btn-sm p-2"><i class="bi bi-view-list"></i> Watchlist</a>
+        <a href="<%= nextLink %>" class="btn text-success bg-success-subtle border border-success-subtle btn-sm p-2 <%= nextDisabled ? 'disabled' : '' %>">Next <i class="bi bi-caret-right-square"></i></a>
+    </div>
+</div>

--- a/views/view.ejs
+++ b/views/view.ejs
@@ -30,26 +30,35 @@
                 <%= data.Title %> (<%= data.Year %>)
             </h1>
             <% if (data.Type === 'series' && season > 0) { %>
-            <div id="series-buttons" class="d-absolute p-0 ps-2 m-0 m-sm-n1 end-0">
-                <button type="button" class="btn btn-dark btn-md mb-1" disabled>
-                     Season <span class="badge bg-warning text-dark"><%= season %></span>
-                </button>
-                <button type="button" class="btn btn-dark btn-md mb-1" disabled>
-                    Episode <span class="badge bg-info text-dark"><%= episode %></span>
-                </button>
-                <div class="mb-2 w-auto">
-                    <a href="<%= `${APP_URL}/view/${id}/${type}/${season}/${Number(episode) - 1}` %>" class="btn text-primary bg-primary-subtle border border-primary-subtle btn-sm p-2"><i class="bi bi-caret-left-square"></i> Previous</a>
-                    <a href="<%= APP_URL %>/watchlist" class="btn text-secondary bg-secondary-subtle border border-secondary-subtle btn-sm p-2"><i class="bi bi-view-list"></i> Watchlist</a>
-                    <a href="<%= `${APP_URL}/view/${id}/${type}/${season}/${Number(episode) + 1}` %>" class="btn text-success bg-success-subtle border border-success-subtle btn-sm p-2">Next <i class="bi bi-caret-right-square"></i></a>
-                </div>
-            </div>
+            <%- include('./partials/series-buttons.ejs') -%>
             <% } %>
         </div>
         <h5 class="card-subtitle mt-2"><%= data.Plot %></h5>
     </div>
 <% } %>
-    <div class="ratio ratio-16x9">
-        <iframe src="<%= iframeSrc %>" referrerpolicy="origin" allow="autoplay; fullscreen" class="w-100"></iframe>
+    <div class="row">
+        <div class="col-12 col-md-8">
+            <div class="ratio ratio-16x9">
+                <iframe src="<%= iframeSrc %>" referrerpolicy="origin" allow="autoplay; fullscreen" class="w-100"></iframe>
+            </div>
+            <% if (type === 'series' && seriesDetail) { %>
+            <div class="d-flex flex-wrap mt-2">
+                <% for (let s = 1; s <= seriesDetail.totalSeasons; s++) { %>
+                    <a href="<%= `${APP_URL}/view/${id}/${type}/${s}/1` %>" class="btn btn-outline-light btn-sm m-1 <%= Number(season) === s ? 'active' : '' %>">Season <%= s %></a>
+                <% } %>
+            </div>
+            <% } %>
+        </div>
+        <% if (type === 'series' && seriesDetail) { %>
+        <div class="col-12 col-md-4">
+            <div class="d-flex flex-wrap flex-md-column mt-2 mt-md-0">
+                <% const currentSeason = seriesDetail.seasons.find(se => se.season === Number(season)) || { episodes: [] }; %>
+                <% currentSeason.episodes.forEach(ep => { %>
+                    <a href="<%= `${APP_URL}/view/${id}/${type}/${season}/${ep.episode}` %>" class="btn btn-outline-info btn-sm text-start m-1 <%= Number(episode) === ep.episode ? 'active' : '' %>"><%= ep.episode %>. <%= ep.title || `Episode ${ep.episode}` %></a>
+                <% }) %>
+            </div>
+        </div>
+        <% } %>
     </div>
 <% if (data.Response !== 'False') { -%>
     <div class="row text-white my-4">


### PR DESCRIPTION
## Summary
- fetch full season and episode details from OMDb
- add season and episode navigation to series views
- limit next/previous buttons to available episodes
- centralize request and series interfaces

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx ejslint views/view.ejs views/partials/series-buttons.ejs`
- `npx jest controllers/appController.spec.ts helpers/appHelper.spec.ts --coverage --collectCoverageFrom='controllers/appController.ts' --collectCoverageFrom='helpers/appHelper.ts'`

------
https://chatgpt.com/codex/tasks/task_e_689ec31da5448332aea43e352f93649d