### PR TITLE
test: add http client coverage and update mocks

### DIFF
--- a/controllers/appController.spec.ts
+++ b/controllers/appController.spec.ts
@@ -1,9 +1,12 @@
 import appController from './appController';
-import axios from 'axios';
+import http from '../helpers/httpClient';
 import { fetchOmdbData, fetchAndUpdatePosters, getSeriesDetail } from '../helpers/appHelper';
 import History from '../models/History';
 
-jest.mock('axios');
+jest.mock('../helpers/httpClient', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
 jest.mock('../helpers/appHelper', () => ({
   fetchOmdbData: jest.fn(),
   fetchAndUpdatePosters: jest.fn(),
@@ -34,7 +37,7 @@ describe('controllers/appController', () => {
   });
 
   test('getHome renders index with movies and series', async () => {
-    (axios.get as jest.Mock)
+    (http.get as jest.Mock)
       .mockResolvedValueOnce({ data: { result: [{ imdb_id: '1' }] } })
       .mockResolvedValueOnce({ data: { result: [{ imdb_id: '2' }] } });
     (fetchAndUpdatePosters as jest.Mock).mockResolvedValue(undefined);
@@ -44,7 +47,7 @@ describe('controllers/appController', () => {
 
     await appController.getHome(req, res, jest.fn());
 
-    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(http.get).toHaveBeenCalledTimes(2);
     expect(fetchAndUpdatePosters).toHaveBeenCalledTimes(2);
     expect(res.render).toHaveBeenCalledWith('index', expect.objectContaining({
       newMovies: [{ imdb_id: '1' }],
@@ -55,7 +58,7 @@ describe('controllers/appController', () => {
   });
 
   test('getHome handles empty results', async () => {
-    (axios.get as jest.Mock)
+    (http.get as jest.Mock)
       .mockResolvedValueOnce({ data: {} })
       .mockResolvedValueOnce({ data: {} });
     (fetchAndUpdatePosters as jest.Mock).mockResolvedValue(undefined);

--- a/helpers/httpClient.spec.ts
+++ b/helpers/httpClient.spec.ts
@@ -1,0 +1,57 @@
+import client from './httpClient';
+import { AxiosError } from 'axios';
+
+describe('helpers/httpClient', () => {
+  let originalAdapter: any;
+
+  beforeEach(() => {
+    originalAdapter = client.defaults.adapter;
+    jest.useFakeTimers();
+    jest.spyOn(global.Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    client.defaults.adapter = originalAdapter;
+    jest.useRealTimers();
+    (Math.random as jest.Mock).mockRestore();
+  });
+
+  test('retries on network error', async () => {
+    let attempt = 0;
+    client.defaults.adapter = jest.fn(async (config) => {
+      attempt++;
+      if (attempt === 1) {
+        const err: any = new Error('Network Error');
+        err.config = config;
+        err.code = 'ECONNRESET';
+        throw err;
+      }
+      return { config, data: 'ok', status: 200, statusText: 'OK', headers: {} };
+    });
+
+    const promise = client.get('http://example.com');
+    await jest.advanceTimersByTimeAsync(300);
+    const res = await promise;
+
+    expect(res.data).toBe('ok');
+    expect(attempt).toBe(2);
+  });
+
+  test('throws original error when config missing', async () => {
+    const handler = (client.interceptors.response as any).handlers[0].rejected;
+    const err = new AxiosError('boom');
+    await expect(handler(err)).rejects.toThrow('boom');
+  });
+
+  test('does not retry on non-retryable error', async () => {
+    const handler = (client.interceptors.response as any).handlers[0].rejected;
+    const err = new AxiosError('Bad Request', 'ERR_BAD_REQUEST', { headers: {} } as any);
+    await expect(handler(err)).rejects.toThrow('Bad Request');
+  });
+
+  test('has expected default configuration', () => {
+    expect(client.defaults.timeout).toBe(10_000);
+    expect(client.defaults.maxRedirects).toBe(5);
+    expect(client.defaults.headers?.Connection).toBe('close');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for HTTP client retry logic and default configuration
- switch appHelper and appController tests to mock the shared HTTP client
- cover non-retryable and missing-config error paths for full client coverage

## Testing
- `yarn test`
- `yarn test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689fae5139c08332ae17d38309a67844