### PR TITLE
feat: add multi server support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ OMDB_API_KEY=your_api_key_here
 ## vidsrc.in, vidsrc.pm, vidsrc.xyz, vidsrc.net
 VIDSRC_DOMAIN=vidsrc.in
 
+## Optional alternate video source. When set, the app uses this domain as Server 2.
+#MULTI_DOMAIN=multiembed.mov
+
 ## Uncomment and change these if you want authentication, profile and watchlist functionality to work.
 ## Be sure to setup a MongoDB first and add your connection string to the MONGO_URI below.
 #MONGO_URI="mongodb://localhost:27017"

--- a/config/app.spec.ts
+++ b/config/app.spec.ts
@@ -12,6 +12,7 @@ describe('config/app', () => {
     delete process.env.APP_URL;
     delete process.env.VERCEL_URL;
     delete process.env.NODE_ENV;
+    delete process.env.MULTI_DOMAIN;
   };
 
   const loadConfig = () => {
@@ -92,5 +93,11 @@ describe('config/app', () => {
   test('falls back to localhost when nothing is set', () => {
     const config = loadConfig();
     expect(config.APP_URL).toBe('http://localhost:3000');
+  });
+
+  test('exposes MULTI_DOMAIN when provided', () => {
+    process.env.MULTI_DOMAIN = 'multi';
+    const config = loadConfig();
+    expect(config.MULTI_DOMAIN).toBe('multi');
   });
 });

--- a/config/app.ts
+++ b/config/app.ts
@@ -96,6 +96,8 @@ const appConfig = () => {
     // The vidsrc player domain has been prone to be taken down. Use one of the following domains if it's not working:
     // vidsrc.in, vidsrc.pm, vidsrc.xyz, vidsrc.net
     VIDSRC_DOMAIN: process.env.VIDSRC_DOMAIN || 'vidsrc.in',
+    // Optional multi-server domain for alternate embeds.
+    MULTI_DOMAIN: process.env.MULTI_DOMAIN,
     /* c8 ignore stop */
   };
 };

--- a/controllers/appController.multidomain.spec.ts
+++ b/controllers/appController.multidomain.spec.ts
@@ -1,0 +1,71 @@
+import { fetchOmdbData, getSeriesDetail } from '../helpers/appHelper';
+import History from '../models/History';
+
+jest.mock('../helpers/appHelper', () => ({
+  fetchOmdbData: jest.fn(),
+  fetchAndUpdatePosters: jest.fn(),
+  getSeriesDetail: jest.fn(),
+}));
+
+jest.mock('../models/History', () => ({
+  findOneAndUpdate: jest.fn(),
+}));
+
+describe('controllers/appController with MULTI_DOMAIN', () => {
+  let appController: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.doMock('../config/app', () => ({
+      VIDSRC_DOMAIN: 'domain',
+      MULTI_DOMAIN: 'multi',
+      APP_URL: 'http://app',
+      APP_NAME: 'name',
+      APP_SUBTITLE: '',
+      APP_DESCRIPTION: '',
+    }));
+    appController = require('./appController').default;
+    (getSeriesDetail as jest.Mock).mockResolvedValue({
+      totalSeasons: 1,
+      seasons: [{ season: 1, episodes: [{ episode: 1 }] }],
+    });
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test('getView uses multiembed for series', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({});
+    const req: any = { params: { q: '', id: 'tt', type: 'series', season: '1', episode: '1' }, user: { id: 'u1' } };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn() };
+    await appController.getView(req, res, jest.fn());
+    expect(res.render).toHaveBeenCalledWith(
+      'view',
+      expect.objectContaining({
+        iframeSrc: 'https://multi/?video_id=tt&s=1&e=1',
+        server1Src: 'https://domain/embed/tv?imdb=tt&season=1&episode=1',
+        server2Src: 'https://multi/?video_id=tt&s=1&e=1',
+        currentServer: '2',
+      })
+    );
+  });
+
+  test('getView uses multiembed for movie', async () => {
+    (fetchOmdbData as jest.Mock).mockResolvedValue({});
+    (History.findOneAndUpdate as jest.Mock).mockResolvedValue({ watched: false });
+    const req: any = { params: { q: '', id: 'tt', type: 'movie' }, user: { id: 'u1' } };
+    const res: any = { locals: { APP_URL: 'http://app' }, render: jest.fn() };
+    await appController.getView(req, res, jest.fn());
+    expect(res.render).toHaveBeenCalledWith(
+      'view',
+      expect.objectContaining({
+        iframeSrc: 'https://multi/?video_id=tt',
+        server1Src: 'https://domain/embed/movie/tt',
+        server2Src: 'https://multi/?video_id=tt',
+        currentServer: '2',
+      })
+    );
+  });
+});

--- a/controllers/appController.spec.ts
+++ b/controllers/appController.spec.ts
@@ -20,6 +20,7 @@ jest.mock('../models/History', () => ({
 
 jest.mock('../config/app', () => ({
   VIDSRC_DOMAIN: 'domain',
+  MULTI_DOMAIN: undefined,
   APP_URL: 'http://app',
   APP_NAME: 'name',
   APP_SUBTITLE: '',
@@ -93,6 +94,10 @@ describe('controllers/appController', () => {
       season: '1',
       episode: '2',
       type: 'series',
+      iframeSrc: 'https://domain/embed/tv?imdb=tt&season=1&episode=2',
+      server1Src: 'https://domain/embed/tv?imdb=tt&season=1&episode=2',
+      server2Src: '',
+      currentServer: '1',
     }));
   });
 
@@ -128,7 +133,17 @@ describe('controllers/appController', () => {
       { $set: { type: 'movie', watched: true } },
       { upsert: true, new: true }
     );
-    expect(res.render).toHaveBeenCalledWith('view', expect.objectContaining({ type: 'movie', watched: true }));
+    expect(res.render).toHaveBeenCalledWith(
+      'view',
+      expect.objectContaining({
+        type: 'movie',
+        watched: true,
+        iframeSrc: 'https://domain/embed/movie/tt',
+        server1Src: 'https://domain/embed/movie/tt',
+        server2Src: '',
+        currentServer: '1',
+      })
+    );
   });
 
   test('getView handles missing history on movie view', async () => {

--- a/controllers/appController.ts
+++ b/controllers/appController.ts
@@ -134,13 +134,22 @@ const appController = {
         );
       }
 
-      const iframeSrc = `https://${appConfig.VIDSRC_DOMAIN}/embed/tv?imdb=${id}&season=${season}&episode=${episode}`;
+      const server1Src = `https://${appConfig.VIDSRC_DOMAIN}/embed/tv?imdb=${id}&season=${season}&episode=${episode}`;
+      const server2Src = appConfig.MULTI_DOMAIN
+        ? `https://${appConfig.MULTI_DOMAIN}/?video_id=${id}&s=${season}&e=${episode}`
+        : '';
+      const useMulti = Boolean(appConfig.MULTI_DOMAIN);
+      const iframeSrc = useMulti ? server2Src : server1Src;
+      const currentServer = useMulti ? '2' : '1';
       const canonical = `${res.locals.APP_URL}/view/${id}/${type}/${season}/${episode}`;
       const data = await fetchOmdbData(id, false);
       const seriesDetail = await getSeriesDetail(id);
       return res.render('view', {
         data,
         iframeSrc,
+        server1Src,
+        server2Src,
+        currentServer,
         query,
         id,
         type,
@@ -162,12 +171,19 @@ const appController = {
       watched = history?.watched || false;
     }
 
-    const iframeSrc = `https://${appConfig.VIDSRC_DOMAIN}/embed/movie/${id}`;
+    const server1Src = `https://${appConfig.VIDSRC_DOMAIN}/embed/movie/${id}`;
+    const server2Src = appConfig.MULTI_DOMAIN ? `https://${appConfig.MULTI_DOMAIN}/?video_id=${id}` : '';
+    const useMulti = Boolean(appConfig.MULTI_DOMAIN);
+    const iframeSrc = useMulti ? server2Src : server1Src;
+    const currentServer = useMulti ? '2' : '1';
     const canonical = `${res.locals.APP_URL}/view/${id}/${type}`;
     const data = await fetchOmdbData(id, false);
     res.render('view', {
       data,
       iframeSrc,
+      server1Src,
+      server2Src,
+      currentServer,
       query,
       id,
       type,

--- a/views/partials/series-buttons.ejs
+++ b/views/partials/series-buttons.ejs
@@ -31,7 +31,26 @@ if (episodeNum >= maxEpisodes) {
 <div id="series-buttons" class="px-1 w-100">
     <div class="btn-group mb-2 w-100">
         <a href="<%= prevLink %>" class="btn bg-primary border border-primary-subtle btn-sm p-2 <%= prevDisabled ? 'disabled' : '' %>"><i class="bi bi-caret-left-square"></i> Previous</a>
-        <a href="<%= APP_URL %>/watchlist" class="btn text-secondary bg-secondary-subtle border border-secondary-subtle btn-sm p-2"><i class="bi bi-view-list"></i> Watchlist</a>
+        <a href="#" id="server-toggle" data-current="<%= currentServer %>" data-server1="<%= server1Src %>" data-server2="<%= server2Src %>" class="btn text-secondary bg-secondary-subtle border border-secondary-subtle btn-sm p-2"><i class="bi bi-hdd-stack"></i> Server <%= currentServer === '1' ? '2' : '1' %></a>
         <a href="<%= nextLink %>" class="btn bg-success border border-success-subtle btn-sm p-2 <%= nextDisabled ? 'disabled' : '' %>">Next <i class="bi bi-caret-right-square"></i></a>
     </div>
 </div>
+<script>
+  (function() {
+    const btn = document.getElementById('server-toggle');
+    const player = document.getElementById('player');
+    if (!btn || !player) return;
+    btn.addEventListener('click', function(e) {
+      e.preventDefault();
+      if (this.dataset.current === '1') {
+        player.src = this.dataset.server2;
+        this.dataset.current = '2';
+        this.innerHTML = '<i class="bi bi-hdd-stack"></i> Server 1';
+      } else {
+        player.src = this.dataset.server1;
+        this.dataset.current = '1';
+        this.innerHTML = '<i class="bi bi-hdd-stack"></i> Server 2';
+      }
+    });
+  })();
+</script>

--- a/views/view.ejs
+++ b/views/view.ejs
@@ -53,7 +53,7 @@
     <div class="series-layout">
         <div class="series-player">
             <div class="ratio ratio-16x9">
-                <iframe src="<%= iframeSrc %>" referrerpolicy="origin" allow="autoplay; fullscreen" class="w-100"></iframe>
+                <iframe id="player" src="<%= iframeSrc %>" referrerpolicy="origin" allow="autoplay; fullscreen" class="w-100"></iframe>
             </div>
         </div>
         <div class="series-episodes d-flex flex-wrap flex-md-column mt-2 mt-md-0">
@@ -95,7 +95,7 @@
     <div class="row">
         <div class="col-12">
             <div class="ratio ratio-16x9">
-                <iframe src="<%= iframeSrc %>" referrerpolicy="origin" allow="autoplay; fullscreen" class="w-100"></iframe>
+                <iframe id="player" src="<%= iframeSrc %>" referrerpolicy="origin" allow="autoplay; fullscreen" class="w-100"></iframe>
             </div>
             <% if (data.Response !== 'False') { -%>
             <div class="row text-white my-4">


### PR DESCRIPTION
## Summary
- add MULTI_DOMAIN config for alternate embed server
- toggle iframe between VIDSRC and multiembed via new Server button
- expose player iframe for script control
- build Server 2 URLs from configurable MULTI_DOMAIN

## Testing
- `npm run lint:ejs`
- `npm run lint:ts`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a3ce0c80a4833292912075fd6512db