### PR TITLE
Add coverage for missing appHelper branch

### DIFF
--- a/helpers/appHelper.spec.ts
+++ b/helpers/appHelper.spec.ts
@@ -137,6 +137,15 @@ describe('helpers/appHelper', () => {
     expect(detail.currentSeason.episodes).toEqual([]);
   });
 
+  test('getSeriesDetail handles missing response data', async () => {
+    (http.request as jest.Mock).mockResolvedValueOnce({});
+    const detail = await helper.getSeriesDetail('tt4', 1);
+    expect(detail).toEqual({
+      totalSeasons: 0,
+      currentSeason: { season: 1, episodes: [] },
+    });
+  });
+
   test('getSeriesDetail returns empty when id missing', async () => {
     const detail = await helper.getSeriesDetail('', 1);
     expect(detail).toEqual({ totalSeasons: 0, currentSeason: { season: 0, episodes: [] } });


### PR DESCRIPTION
## Summary
- test: exercise path when `getSeriesDetail` receives response without data

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68aceeb7ef2c8332a15f016e6c1d3bd9