### PR TITLE
fix: prevent home page crash when latest feed returns 403

### DIFF
--- a/controllers/appController.spec.ts
+++ b/controllers/appController.spec.ts
@@ -94,6 +94,27 @@ describe('controllers/appController', () => {
     }));
   });
 
+  test('getHome handles upstream failures without crashing', async () => {
+    (http.get as jest.Mock)
+      .mockRejectedValueOnce(new Error('403'))
+      .mockResolvedValueOnce({ data: { result: [{ imdb_id: '2' }] } });
+    (fetchAndUpdatePosters as jest.Mock).mockResolvedValue(undefined);
+    (getLatest as jest.Mock).mockReturnValue(undefined);
+
+    const req: any = { query: {}, user: {} };
+    const res: any = {
+      locals: { APP_URL: 'http://app', CARD_TYPE: 'card' },
+      render: jest.fn(),
+    };
+
+    await appController.getHome(req, res, jest.fn());
+
+    expect(res.render).toHaveBeenCalledWith('index', expect.objectContaining({
+      newMovies: [],
+      newSeries: [{ imdb_id: '2' }],
+    }));
+  });
+
   test('getHome returns cached results when available', async () => {
     (getLatest as jest.Mock).mockReturnValue({
       movies: [{ imdb_id: 'm1' }],

--- a/controllers/appController.spec.ts
+++ b/controllers/appController.spec.ts
@@ -109,6 +109,7 @@ describe('controllers/appController', () => {
 
     await appController.getHome(req, res, jest.fn());
 
+    expect(setLatest).not.toHaveBeenCalled();
     expect(res.render).toHaveBeenCalledWith('index', expect.objectContaining({
       newMovies: [],
       newSeries: [{ imdb_id: '2' }],

--- a/controllers/appController.ts
+++ b/controllers/appController.ts
@@ -105,7 +105,12 @@ const appController = {
       fetchAndUpdatePosters(newSeries),
     ]);
 
-    setLatest({ movies: newMovies, series: newSeries });
+    const hasFeedFailure =
+      movieResult.status === 'rejected' || seriesResult.status === 'rejected';
+
+    if (!hasFeedFailure) {
+      setLatest({ movies: newMovies, series: newSeries });
+    }
 
     res.render('index', {
       newMovies,

--- a/controllers/appController.ts
+++ b/controllers/appController.ts
@@ -82,13 +82,23 @@ const appController = {
       });
     }
 
-    const [axiosMovieResponse, axiosSeriesResponse] = await Promise.all([
+    const [movieResult, seriesResult] = await Promise.allSettled([
       http.get(`https://${appConfig.VIDSRC_DOMAIN}/movies/latest/page-1.json`),
       http.get(`https://${appConfig.VIDSRC_DOMAIN}/tvshows/latest/page-1.json`),
     ]);
 
-    let newMovies = axiosMovieResponse.data.result || [];
-    let newSeries = axiosSeriesResponse.data.result || [];
+    let newMovies =
+      movieResult.status === 'fulfilled' ? movieResult.value.data.result || [] : [];
+    let newSeries =
+      seriesResult.status === 'fulfilled' ? seriesResult.value.data.result || [] : [];
+
+    if (movieResult.status === 'rejected') {
+      console.warn('Failed to fetch latest movies; continuing with empty dataset');
+    }
+
+    if (seriesResult.status === 'rejected') {
+      console.warn('Failed to fetch latest series; continuing with empty dataset');
+    }
 
     await Promise.all([
       fetchAndUpdatePosters(newMovies),
@@ -132,7 +142,7 @@ const appController = {
    */
   getView: asyncHandler(async (req: AuthRequest, res: Response) => {
     const query = req.params.q || '';
-    const id = req.params.id;
+    const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
     const type = req.params.type as 'movie' | 'series';
 
     const cookieHeader =
@@ -143,8 +153,12 @@ const appController = {
     const preferredServer = match ? (match[1] as '1' | '2') : undefined;
 
     if (type === 'series') {
-      let season = req.params.season;
-      let episode = req.params.episode;
+      let season = Array.isArray(req.params.season)
+        ? req.params.season[0]
+        : req.params.season;
+      let episode = Array.isArray(req.params.episode)
+        ? req.params.episode[0]
+        : req.params.episode;
 
       if ((!season || !episode) && req.user) {
         const redirectTo = await getResumeRedirect(req.user.id, id);


### PR DESCRIPTION
### Motivation
- The index route crashed when one of the upstream latest-feed endpoints returned a non-2xx response (e.g. HTTP 403) because both requests were awaited via `Promise.all` and an Axios error propagated. 
- Route handlers also needed to be robust against Express `req.params` being `string | string[]` to avoid TypeScript and runtime issues.

### Description
- Switched home-page latest content fetches to `Promise.allSettled` and treat each feed independently so a failing feed falls back to an empty array while successful feeds still render. 
- Added lightweight warning output (`console.warn`) when a latest-feed fetch is rejected to aid troubleshooting without interrupting rendering. 
- Normalized route param extraction in `getView` by coercing `req.params.id`, `req.params.season`, and `req.params.episode` to strings when an array is present to prevent `string | string[]` type errors. 
- Added a unit test `getHome handles upstream failures without crashing` that simulates one rejected feed and verifies the page still renders with partial data.

### Testing
- Ran `yarn test controllers/appController.spec.ts --runInBand` and the spec file passed (`17 passed`).
- Ran `yarn lint:ts` in this environment but it fails due to missing type definition files for `jest`/`node`, which is unrelated to the functional change in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf23977708332aa5f92ff9bb0ad08)